### PR TITLE
WIP: Debug failure to call create_buffer_object() on Intel iGPU

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -136,14 +136,23 @@ fn main() {
 
     let gbm = GbmDevice::new(gpu).expect("Failed to create GbmDevice");
 
-    let mut buffer_object = gbm
-        .create_buffer_object::<()>(
-            width,
-            height,
-            BufferFormat::Argb8888,
-            BufferObjectFlags::SCANOUT | BufferObjectFlags::WRITE,
-        )
-        .unwrap();
+    let usage = BufferObjectFlags::SCANOUT | BufferObjectFlags::WRITE;
+    use BufferFormat::*;
+    for format in [
+        Abgr8888, Argb8888, Bgr888, Bgra8888, Bgrx8888, Rgb888, Rgb888_a8, Rgba8888, Rgbx8888,
+        Xbgr8888, Xrgb8888,
+    ] {
+        println!(
+            "Is {} format supported for {:?} usage: {}",
+            format,
+            usage,
+            gbm.is_format_supported(format, usage)
+        );
+    }
+
+    let format = Argb8888;
+    println!("gbm.create_buffer_object(width: {width}, height: {height}, format: {format}, usage: {usage:?})");
+    let mut buffer_object = gbm.create_buffer_object::<()>(width, height, format, usage).unwrap();
 
     let buffer_data = vec![255u8; (width * height * 4) as usize];
 


### PR DESCRIPTION
Just some WIP debugging to see if I can get `just-gl` running on Intel iGPU with `i915` 
driver.

Relates to #4.

Currently I'm getting:
<details><summary>prelude</summary>

```
[src/main.rs:89] gpu.get_driver().expect("Failed to get GPU driver info") = Driver {
    name: "i915",
    date: "20201103",
    desc: "Intel Graphics",
}
[src/main.rs:90] gpu.get_bus_id().expect("Failed to get GPU bus ID") = ""
Connectors:
        eDP-1, Connected=✅
        HDMI-A-1, Connected=❌
        DP-1, Connected=❌
        DP-2, Connected=❌
        DP-3, Connected=❌
        DP-4, Connected=❌
Using connector: eDP-1
Using mode: Mode { name: "1920x1200", clock: 156100, size: (1920, 1200), hsync: (1936, 1952, 2104), vsync: (1203, 1217, 1236), hskew: 0, vscan: 0, vrefresh: 60, mode_type: PREFERRED | DRIVER }
[src/main.rs:125] encoder = Info {
    handle: encoder::Handle(
        235,
    ),
    enc_type: TMDS,
    crtc: Some(
        crtc::Handle(
            80,
        ),
    ),
    pos_crtcs: 15,
    pos_clones: 1,
}
[src/main.rs:132] crtc = Info {
    handle: crtc::Handle(
        80,
    ),
    position: (
        0,
        0,
    ),
    mode: Some(
        Mode {
            name: "1920x1200",
            clock: 156100,
            size: (
                1920,
                1200,
            ),
            hsync: (
                1936,
                1952,
                2104,
            ),
            vsync: (
                1203,
                1217,
                1236,
            ),
            hskew: 0,
            vscan: 0,
            vrefresh: 60,
            mode_type: PREFERRED | DRIVER,
        },
    ),
    fb: Some(
        framebuffer::Handle(
            289,
        ),
    ),
    gamma_length: 256,
}
```

</details>

```
Is AB24 format supported for SCANOUT | WRITE usage: true
Is AR24 format supported for SCANOUT | WRITE usage: true
Is BG24 format supported for SCANOUT | WRITE usage: false
Is BA24 format supported for SCANOUT | WRITE usage: false
Is BX24 format supported for SCANOUT | WRITE usage: false
Is RG24 format supported for SCANOUT | WRITE usage: false
Is R8A8 format supported for SCANOUT | WRITE usage: false
Is RA24 format supported for SCANOUT | WRITE usage: false
Is RX24 format supported for SCANOUT | WRITE usage: false
Is XB24 format supported for SCANOUT | WRITE usage: true
Is XR24 format supported for SCANOUT | WRITE usage: true
gbm.create_buffer_object(width: 1920, height: 1200, format: AR24, usage: SCANOUT | WRITE)
thread 'main' panicked at src/main.rs:155:90:
called `Result::unwrap()` on an `Err` value: Os { code: 22, kind: InvalidInput, message: "Invalid argument" }
```

Which puzzles me, because the format and usage combination is claimed to be supported.