### PR TITLE
trivial: don't diff Cargo.lock

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Cargo.lock -diff


### PR DESCRIPTION
Picked up by `git diff`, but I think GitHub uses that too.

Use `git diff --text` if you really want to see changes to `Cargo.toml`.