### PR TITLE
Autodiscover examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,3 @@ glium = "0.33"
 glutin = "0.30"
 # Glutin 0.30 depends on rwh 0.5
 raw-window-handle = "0.5"
-
-[[example]]
-name = "colors"


### PR DESCRIPTION
Just pretext to add the trailing newline, please pardon my OSD. :sweat_smile:

`cargo run --example colors` still works, and it is being build by default etc.